### PR TITLE
Updates: Search by email and setup intent

### DIFF
--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -24,6 +24,8 @@ part 'src/messages/requests/create_customer.dart';
 part 'src/messages/requests/create_payment_intent.dart';
 part 'src/messages/requests/create_portal_session.dart';
 part 'src/messages/requests/create_setup_intent.dart';
+part 'src/messages/requests/update_setup_intent.dart';
+part 'src/messages/requests/confirm_setup_intent.dart';
 part 'src/messages/requests/create_refund.dart';
 part 'src/messages/requests/list_prices.dart';
 part 'src/messages/requests/list_products.dart';

--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -1116,6 +1116,52 @@ Map<String, dynamic> _$CreateSetupIntentRequestToJson(
   return val;
 }
 
+UpdateSetupIntentRequest _$UpdateSetupIntentRequestFromJson(
+        Map<String, dynamic> json) =>
+    UpdateSetupIntentRequest(
+      id: json['id'] as String,
+      paymentMethod: json['payment_method'] as String?,
+    );
+
+Map<String, dynamic> _$UpdateSetupIntentRequestToJson(
+    UpdateSetupIntentRequest instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('payment_method', instance.paymentMethod);
+  return val;
+}
+
+ConfirmSetupIntentRequest _$ConfirmSetupIntentRequestFromJson(
+        Map<String, dynamic> json) =>
+    ConfirmSetupIntentRequest(
+      id: json['id'] as String,
+      paymentMethod: json['payment_method'] as String?,
+    );
+
+Map<String, dynamic> _$ConfirmSetupIntentRequestToJson(
+    ConfirmSetupIntentRequest instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('payment_method', instance.paymentMethod);
+  return val;
+}
+
 CreateRefundRequest _$CreateRefundRequestFromJson(Map<String, dynamic> json) =>
     CreateRefundRequest(
       charge: json['charge'] as String?,

--- a/lib/src/messages/requests/confirm_setup_intent.dart
+++ b/lib/src/messages/requests/confirm_setup_intent.dart
@@ -1,0 +1,19 @@
+part of '../../../messages.dart';
+
+@JsonSerializable()
+class ConfirmSetupIntentRequest {
+  /// Unique identifier for the object.
+  final String id;
+
+  final String? paymentMethod;
+
+  ConfirmSetupIntentRequest({
+    required this.id,
+    this.paymentMethod,
+  });
+
+  factory ConfirmSetupIntentRequest.fromJson(Map<String, dynamic> json) =>
+      _$ConfirmSetupIntentRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ConfirmSetupIntentRequestToJson(this);
+}

--- a/lib/src/messages/requests/update_setup_intent.dart
+++ b/lib/src/messages/requests/update_setup_intent.dart
@@ -1,0 +1,19 @@
+part of '../../../messages.dart';
+
+@JsonSerializable()
+class UpdateSetupIntentRequest {
+  /// Unique identifier for the object.
+  final String id;
+
+  final String? paymentMethod;
+
+  UpdateSetupIntentRequest({
+    required this.id,
+    this.paymentMethod,
+  });
+
+  factory UpdateSetupIntentRequest.fromJson(Map<String, dynamic> json) =>
+      _$UpdateSetupIntentRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UpdateSetupIntentRequestToJson(this);
+}

--- a/lib/src/messages/requests/update_setup_intent.dart
+++ b/lib/src/messages/requests/update_setup_intent.dart
@@ -15,5 +15,6 @@ class UpdateSetupIntentRequest {
   factory UpdateSetupIntentRequest.fromJson(Map<String, dynamic> json) =>
       _$UpdateSetupIntentRequestFromJson(json);
 
-  Map<String, dynamic> toJson() => _$UpdateSetupIntentRequestToJson(this);
+  Map<String, dynamic> toJson() =>
+      _$UpdateSetupIntentRequestToJson(this)..remove('id');
 }

--- a/lib/src/resources/customer.dart
+++ b/lib/src/resources/customer.dart
@@ -18,8 +18,13 @@ class CustomerResource extends Resource<Customer> {
     return Customer.fromJson(map);
   }
 
-  Future<List<Customer>> retrieveAll(String customerId) async {
-    final map = await get('customers');
+  Future<List<Customer>> search(
+    String email,
+  ) async {
+    final map = await get('customers/search', queryParameters: {
+      'query': 'email=$email',
+    });
+
     return (map['data'] as List).map((e) => Customer.fromJson(e)).toList();
   }
 

--- a/lib/src/resources/customer.dart
+++ b/lib/src/resources/customer.dart
@@ -22,7 +22,7 @@ class CustomerResource extends Resource<Customer> {
     String email,
   ) async {
     final map = await get('customers/search', queryParameters: {
-      'query': 'email=$email',
+      'query': "email='$email'",
     });
 
     return (map['data'] as List).map((e) => Customer.fromJson(e)).toList();

--- a/lib/src/resources/setup_intent.dart
+++ b/lib/src/resources/setup_intent.dart
@@ -16,9 +16,33 @@ class SetupIntentResource extends Resource<SetupIntent> {
     return SetupIntent.fromJson(response);
   }
 
+  Future<SetupIntent> update(UpdateSetupIntentRequest request) async {
+    final setupIntentId = request.id;
+    final response = await post(
+      'setup_intents/$setupIntentId',
+      data: request.toJson(),
+    );
+    return SetupIntent.fromJson(response);
+  }
+
   Future<SetupIntent> retrieve(String setupIntentId) async {
     final map = await get('setup_intents/$setupIntentId');
     return SetupIntent.fromJson(map);
+  }
+
+  /// Returns true if successful.
+  Future<bool> confirm(ConfirmSetupIntentRequest request) async {
+    final setupIntentId = request.id;
+    try {
+      await post(
+        'setup_intents/$setupIntentId/confirm',
+        data: request.toJson(),
+      );
+    } catch (e) {
+      log.warning(e);
+      return false;
+    }
+    return true;
   }
 
   /// Returns true if successful.
@@ -27,7 +51,6 @@ class SetupIntentResource extends Resource<SetupIntent> {
       await post('setup_intents/$setupIntentId/cancel');
     } catch (e) {
       log.warning(e);
-
       return false;
     }
     return true;


### PR DESCRIPTION
Added functionalities:
1. Search a customer in Stripe based on the email
2. Create a new setup intent and confirm it to save a payment method for later usage. 